### PR TITLE
Merge dev branch with recent improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .DS_Store
 .vscode/
-Main.cpp
-Main
+examples/
+*.d
+*.o
+*__Debug
+*__Release

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ extern "C"
 ```VB
 Private Declare PtrSafe Function IncrementArrayBy _
 Lib "/Library/Application Support/Microsoft/YourLibrary.dylib" _
-(ByRef v as Variant, ByVal d as Double) As Variant      ' Always pass Variants ByRef!
+(ByRef v as Variant, ByVal d as Double) As Variant     ' Always pass Variants ByRef!
 
 Public Function CallLibFunction(r as Range) as Variant
-    CallLibFunction = IncrementArrayBy(r.Value, 2.5)    ' Extract the Range's values first!!!
+    CallLibFunction = IncrementArrayBy(r.Value2, 2.5)  ' Extract the Range's values first!!!
 End Function
 ```
 

--- a/include/MinXL/Core/Exception.hpp
+++ b/include/MinXL/Core/Exception.hpp
@@ -34,7 +34,7 @@ namespace mxl
             auto nLength = std::strlen(message) + std::strlen(file_line) + 32;
             m_What = new char[nLength];
 
-            std::snprintf(m_What, nLength, "[Aspirin++] Exception: %s (at %s)", message, file_line);
+            std::snprintf(m_What, nLength, "[MinXL] Exception: %s (at %s)", message, file_line);
         }
 
         const char* what() const noexcept override

--- a/include/MinXL/Core/Exception.hpp
+++ b/include/MinXL/Core/Exception.hpp
@@ -19,7 +19,7 @@ namespace mxl
     {
         consteval auto StripPath(std::string_view path)
         {
-            return path.substr(path.find("src/") + sizeof("src/") - 1).data();
+            return path.substr(path.find("include/") + sizeof("include/") - 1).data();
         }
     }
 

--- a/include/MinXL/Core/Implementation/Array.hpp
+++ b/include/MinXL/Core/Implementation/Array.hpp
@@ -211,29 +211,68 @@ namespace mxl
     }
 
 
+    template<ArrayValue _Ty>
+    inline Tuple<_Ty>::Tuple(std::initializer_list<_Ty> args): Array<_Ty>(args.size(), 1)
+    {
+        for (size_t i = 0; auto&& a : args)
+            this->operator()(i++, 0) = a;
+    }
+
+
+    template<ArrayValue _Ty>
+    template<Castable<_Ty>... _Ts>
+    inline Tuple<_Ty>::Tuple(_Ts... args): Array<_Ty>(sizeof...(_Ts), 1)
+    {
+        int32_t i = 0;
+        (...,
+            (this->operator()(i++, 0) = static_cast<Variant>(std::move(args)))
+        );  
+    }
+    
+
+    // Returns pointer to first element.
     template <ArrayValue _Ty>
     inline _Ty* begin(Array<_Ty>& arr)
     {
         return arr.Data();
     }
 
-
+    
+    // Returns pointer to after the last element.
     template <ArrayValue _Ty>
     inline _Ty* end(Array<_Ty>& arr)
     { 
         return arr.Data() + arr.Size();
     }
 
-
+    
+    // Returns const pointer to first element.
     template <ArrayValue _Ty>
     inline const _Ty* begin(const Array<_Ty>& arr)
     { 
         return arr.Data();
     }
 
-
+    
+    // Returns pointer to after the last element.
     template <ArrayValue _Ty>
     inline const _Ty* end(const Array<_Ty>& arr)
+    { 
+        return arr.Data() + arr.Size();
+    }
+
+    
+    // Returns const pointer to first element.
+    template <ArrayValue _Ty>
+    inline const _Ty* cbegin(const Array<_Ty>& arr)
+    { 
+        return arr.Data();
+    }
+
+    
+    // Returns pointer to after the last element.
+    template <ArrayValue _Ty>
+    inline const _Ty* cend(const Array<_Ty>& arr)
     { 
         return arr.Data() + arr.Size();
     }

--- a/include/MinXL/Core/Implementation/Array.hpp
+++ b/include/MinXL/Core/Implementation/Array.hpp
@@ -65,19 +65,6 @@ namespace mxl
     {
     }
 
-    // template<ArrayValue _Ty>
-    // template<typename...>
-    // inline Array<_Ty>::Array(_Ty&&... args)
-    // {
-    //     if (Allocate(sizeof...(_Ty), 1))
-    //     {
-    //         int32_t i = 0;
-    //         (...,
-    //             (operator()(i++, 0) = std::move(args))
-    //         );
-    //     }
-    // }
-
 
     template<ArrayValue _Ty>
     inline Array<_Ty>::~Array()

--- a/include/MinXL/Core/Implementation/Array.hpp
+++ b/include/MinXL/Core/Implementation/Array.hpp
@@ -1,14 +1,15 @@
 #pragma once
 
+#include "MinXL/Core/Types.hpp"
 #include "MinXL/Core/Interface/Array.hpp"
+
 
 namespace mxl
 {
     template<ArrayValue _Ty>
-    inline Array<_Ty>::Array()
+    inline Array<_Ty>::Array(): _Header{}, _Body{}
     {
     }
-
 
     template<ArrayValue _Ty>
     inline Array<_Ty>::Array(const uint64_t rows, const uint64_t cols)
@@ -21,17 +22,15 @@ namespace mxl
     inline Array<_Ty>::Array(const Array<_Ty>& other)
     {
         if (Allocate(other.Rows(), other.Columns()))
-            std::copy(cbegin(other), cend(other), begin(*this));
+            std::copy(begin(other), end(other), begin(*this));
     }
 
 
     template<ArrayValue _Ty>
     inline Array<_Ty>::Array(Array<_Ty>&& other)
     {
-        _Header         = other._Header;
-        _Body           = other._Body;
-        other._Header   = ArrayHeader{};
-        other._Body     = ArrayBody{};
+        std::memcpy(this, &other, sizeof(Array<_Ty>));
+        std::memset(&other, 0, sizeof(Array<_Ty>));
     }
 
 
@@ -39,7 +38,7 @@ namespace mxl
     inline Array<_Ty>& Array<_Ty>::operator=(const Array<_Ty>& other)
     {
         if (Allocate(other.Rows(), other.Columns()))
-            std::copy(cbegin(other), cend(other), begin(*this));
+            std::copy(begin(other), end(other), begin(*this));
 
         return *this;
     }
@@ -48,92 +47,36 @@ namespace mxl
     template<ArrayValue _Ty>
     inline Array<_Ty>& Array<_Ty>::operator=(Array<_Ty>&& other)
     {
-        _Header         = other._Header;
-        _Body           = other._Body;
-        other._Header   = ArrayHeader{};
-        other._Body     = ArrayBody{};
+        std::memcpy(this, &other, sizeof(Array<_Ty>));
+        std::memset(&other, 0, sizeof(Array<_Ty>));
 
         return *this;
     }
 
 
     template<ArrayValue _Ty>
-    inline Array<_Ty>::Array(const Variant& var)
+    inline Array<_Ty>::Array(const Variant& var): Array<_Ty>(static_cast<const Array<_Ty>&>(var))
     {
-        const auto value = var.Value();
-
-        if (var.IsArray() && value.Array)
-        {
-            if (value.Array->Data)
-            {
-                const uint64_t cols = value.Array->Columns.ElementCount;
-                const uint64_t rows = value.Array->Rows.ElementCount;
-                constexpr auto type = Type::GetID<_Ty>();
-
-                if (var.IsArrayOfType(type))
-                {
-                    auto src  = reinterpret_cast<Array*>((char*)value.Array - sizeof(ArrayHeader));
-
-                    if (Allocate(rows, cols))
-                        std::copy(cbegin(*src), cend(*src), begin(*this));
-                }
-                else
-                {
-                    MXL_THROW("Invalid attempt to copy-construct Array from Variant; type mismatch detected");
-                }
-            }
-        }
-        else
-        {
-            MXL_THROW("Invalid attempt to copy-construct Array from Variant; passed Variant is not an array");
-        }
     }
 
 
     template<ArrayValue _Ty>
-    inline Array<_Ty>::Array(Variant&& var)
+    inline Array<_Ty>::Array(Variant&& var): Array<_Ty>(std::move(var).operator Array<_Ty>())
     {
-        auto value = var.Value();
-
-        if (var.IsArray() && value.Array)
-        {
-            constexpr auto type = Type::GetID<_Ty>();
-
-            if (var.IsArrayOfType(type))
-            {
-                auto src = reinterpret_cast<Array*>((char*)value.Array - sizeof(ArrayHeader));
-
-                _Header         = src->_Header;
-                _Body           = src->_Body;
-                src->_Header    = ArrayHeader{};
-                src->_Body      = ArrayBody{};
-            }
-            else
-            {
-                MXL_THROW("Invalid attempt to move-construct Array from Variant; type mismatch");
-            }
-        }
-        else
-        {
-            MXL_THROW("Invalid attempt to move-construct Array from Variant; passed Variant is not an array");
-        }
     }
 
-
-    template<ArrayValue _Ty>
-    inline Array<_Ty>::Array(const std::vector<_Ty>& vec)
-    {
-        if (Allocate(vec.size(), 1))
-            std::copy(vec.cbegin(), vec.cend(), begin(*this));
-    }
-
-
-    template<ArrayValue _Ty>
-    inline Array<_Ty>::Array(const std::initializer_list<_Ty>&& vec)
-    {
-        if (Allocate(vec.size(), 1))
-            std::copy(vec.begin(), vec.end(), begin(*this));
-    }
+    // template<ArrayValue _Ty>
+    // template<typename...>
+    // inline Array<_Ty>::Array(_Ty&&... args)
+    // {
+    //     if (Allocate(sizeof...(_Ty), 1))
+    //     {
+    //         int32_t i = 0;
+    //         (...,
+    //             (operator()(i++, 0) = std::move(args))
+    //         );
+    //     }
+    // }
 
 
     template<ArrayValue _Ty>
@@ -142,8 +85,7 @@ namespace mxl
         if (_Body.Data)
             std::free(_Body.Data);
         
-        _Header = ArrayHeader{};
-        _Body   = ArrayBody{};
+        std::memset(this, 0, sizeof(Array<_Ty>));
     }
 
 
@@ -151,10 +93,6 @@ namespace mxl
     inline bool Array<_Ty>::Allocate(const uint64_t rows, const uint64_t cols)
     {
         constexpr auto type = Type::GetID<_Ty>();
-        
-        static_assert(
-            type != Type::ID::Empty, "Attempt to instantiate Array with unsupported type."
-        );
 
         if (auto buffer = std::calloc(rows * cols, sizeof(_Ty)))
         {
@@ -274,30 +212,29 @@ namespace mxl
 
 
     template <ArrayValue _Ty>
-    inline auto begin(Array<_Ty>& arr)
+    inline _Ty* begin(Array<_Ty>& arr)
     {
         return arr.Data();
     }
 
 
     template <ArrayValue _Ty>
-    inline auto end(Array<_Ty>& arr)
+    inline _Ty* end(Array<_Ty>& arr)
     { 
         return arr.Data() + arr.Size();
     }
 
 
     template <ArrayValue _Ty>
-    inline auto cbegin(const Array<_Ty>& arr)
+    inline const _Ty* begin(const Array<_Ty>& arr)
     { 
         return arr.Data();
     }
 
 
     template <ArrayValue _Ty>
-    inline auto cend(const Array<_Ty>& arr)
+    inline const _Ty* end(const Array<_Ty>& arr)
     { 
         return arr.Data() + arr.Size();
     }
 }
-

--- a/include/MinXL/Core/Implementation/String.hpp
+++ b/include/MinXL/Core/Implementation/String.hpp
@@ -24,7 +24,7 @@ namespace mxl
     }
 
 
-    inline String::String(const char* str): String(Str8to16(str))
+    inline String::String(const char* str): String(Char8to16(str).get())
     {
     }
 
@@ -103,6 +103,12 @@ namespace mxl
     inline char16_t* String::Buffer() const
     {
         return _Buffer;
+    }
+
+
+    inline std::unique_ptr<char[]> String::CStr() const
+    {
+        return Char16to8(Buffer());
     }
 
 
@@ -186,31 +192,30 @@ namespace mxl
     }
 
 
-    inline const char* String::Str16to8(const char16_t* str)
+    inline std::unique_ptr<char[]> String::Char16to8(const char16_t* str)
     {
         if (!(*str))
-            return new char[1]{'\0'};
+            return std::unique_ptr<char[]>(new char[1]{'\0'});
 
         const char16_t* end = str;
 
         while (*end++);
 
         int n = end - str;
-        char* converted = new char[n];
+        auto converted = std::unique_ptr<char[]>(new char[n]{'\0'});
 
         for (int c = 0; c < n - 1; c++)
             converted[c] = (char)(str[c]);
 
-        converted[n - 1] = '\0';
         return converted;
     }
 
 
-    inline const char16_t* String::Str8to16(const char* str)
+    inline std::unique_ptr<char16_t[]> String::Char8to16(const char* str)
     {
         if (!(*str))
         {
-            return new char16_t[1]{'\0'};
+            return std::unique_ptr<char16_t[]>(new char16_t[1]{'\0'});
         }
 
         const char* end = str;
@@ -218,17 +223,16 @@ namespace mxl
         while (*end++);
 
         int n = end - str;
-        char16_t* converted = new char16_t[n];
+        auto converted = std::unique_ptr<char16_t[]>(new char16_t[n]{'\0'});
 
         for (int c = 0; c < n - 1; c++)
             converted[c] = (char16_t)(str[c]);
 
-        converted[n - 1] = '\0';
         return converted;
     }
 
     inline std::ostream& operator<<(std::ostream &os, const String& str)
     {
-        return os << String::Str16to8(str.Buffer());
+        return os << str.CStr();
     }
 }

--- a/include/MinXL/Core/Implementation/Variant.hpp
+++ b/include/MinXL/Core/Implementation/Variant.hpp
@@ -97,6 +97,9 @@ namespace mxl
     }
 
 
+    //
+    // Returns ID of the underlying data type.
+    //
     inline Type::ID Variant::TypeID() const
     {
         return _Type;
@@ -133,21 +136,30 @@ namespace mxl
     }
 
 
+    //
+    // Returns ID of the data type contained in the underlying mxl::Array.
+    //
     inline Type::ID Variant::ArrayTypeID() const
     {
         return IsArray() ? _Type ^ Type::ID::Array : Type::ID::Empty;
     }
 
 
-    inline bool Variant::IsArrayOfTypeID(Type::ID type) const
+    //
+    // Checks if parameter matches ID of the data type contained in the underlying mxl::Array.
+    //
+    inline bool Variant::IsArrayOfTypeID(Type::ID id) const
     {
-        return IsArray() && (type == (_Type ^ Type::ID::Array));
+        return IsArray() && (id == (_Type ^ Type::ID::Array));
     }
 
 
-    inline bool Variant::IsArrayOfTypeID(uint32_t type) const
+    //
+    // Checks if parameter matches ID of the data type contained in the underlying mxl::Array.
+    //
+    inline bool Variant::IsArrayOfTypeID(uint32_t id) const
     {
-        return IsArray() && ((Type::ID)type == (_Type ^ Type::ID::Array));
+        return IsArray() && ((Type::ID)id == (_Type ^ Type::ID::Array));
     }
 
 
@@ -184,6 +196,9 @@ namespace mxl
     }
 
 
+    //
+    // Performs a "self-move" into a new mxl::String and returns it.
+    //
     inline Variant::operator String() &&
     {
         String str = std::move(operator String&());
@@ -194,12 +209,18 @@ namespace mxl
     }
 
 
+    //
+    // Copies underlying mxl::String into a new one and returns it.
+    //
     inline Variant::operator String() const &
     {
         return operator const String&();
     }
 
 
+    //
+    // Exposes a reference to the underlying mxl::String.
+    //
     inline Variant::operator String&()
     {
         if (IsString())
@@ -209,6 +230,9 @@ namespace mxl
     }
 
 
+    //
+    // Exposes a const reference to the underlying mxl::String.
+    //
     inline Variant::operator const String&() const
     {
         return static_cast<const String&>(
@@ -255,6 +279,9 @@ namespace mxl
     }
 
 
+    //
+    // Performs a "self-move" into a new mxl::Array and returns it.
+    //
     template <ArrayValue _Ty>
     inline Variant::operator Array<_Ty>() &&
     {
@@ -266,6 +293,9 @@ namespace mxl
     }
 
 
+    //
+    // Copies underlying mxl::Array into a new one and returns it.
+    //
     template <ArrayValue _Ty>
     inline Variant::operator Array<_Ty>() const &
     {
@@ -273,6 +303,9 @@ namespace mxl
     }
 
 
+    //
+    // Exposes a reference to the underlying mxl::Array.
+    //
     template <ArrayValue _Ty>
     inline Variant::operator Array<_Ty>&()
     {
@@ -292,6 +325,9 @@ namespace mxl
     }
 
 
+    //
+    // Exposes a const reference to the underlying mxl::Array.
+    //
     template <ArrayValue _Ty>
     inline Variant::operator const Array<_Ty>&() const
     {
@@ -313,6 +349,9 @@ namespace mxl
     }
 
 
+    //
+    // Exposes a reference to the underlying numeric value.
+    //
     template <Numeric _Ty>
     inline Variant::operator _Ty&()
     {
@@ -334,6 +373,9 @@ namespace mxl
     }
 
 
+    //
+    // Exposes a const reference to the underlying numeric value.
+    //
     template <Numeric _Ty>
     inline Variant::operator const _Ty&() const
     {
@@ -343,6 +385,9 @@ namespace mxl
     }
 
 
+    //
+    // Frees owned resources.
+    //
     inline void Variant::Deallocate()
     {
         if (IsArray())

--- a/include/MinXL/Core/Implementation/Variant.hpp
+++ b/include/MinXL/Core/Implementation/Variant.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
+#include "MinXL/Core/Types.hpp"
+
+#include "MinXL/Core/Interface/Array.hpp"
+#include "MinXL/Core/Interface/String.hpp"
 #include "MinXL/Core/Interface/Variant.hpp"
+
 
 namespace mxl
 {
@@ -8,29 +13,27 @@ namespace mxl
     {
     }
 
-    inline Variant::~Variant()
+
+    inline Variant::Variant(Variant&& other): _Type{other._Type}, _Value{other._Value}
     {
-        Deallocate();
+        std::memset(&other, 0, sizeof(Variant));
     }
+
 
     inline Variant::Variant(const Variant& other)
     {
-        // For Variants containing Arrays and Strings, we take advantage of the fact that these classes
-        // already know how to construct themselves from a Variant; and Variant already knows
-        // how to construct itselft from them.
-
         if (other.IsArray())
         {
             Variant temp;
 
-            switch(other.ArrayType())
+            switch(other.ArrayTypeID())
             {
-                case Type::ID::Int16:   temp = Variant{Array<int16_t>{other}};  break;
-                case Type::ID::Int32:   temp = Variant{Array<int32_t>{other}};  break;
-                case Type::ID::Int64:   temp = Variant{Array<int64_t>{other}};  break;
-                case Type::ID::Float:   temp = Variant{Array<float>  {other}};  break;
-                case Type::ID::Double:  temp = Variant{Array<double> {other}};  break;
-                case Type::ID::Variant: temp = Variant{Array<Variant>{other}};  break;
+                case Type::ID::Int16:   temp = static_cast<const Array<int16_t>&>(other);  break;
+                case Type::ID::Int32:   temp = static_cast<const Array<int32_t>&>(other);  break;
+                case Type::ID::Int64:   temp = static_cast<const Array<int64_t>&>(other);  break;
+                case Type::ID::Float:   temp = static_cast<const Array<float>&>(other);    break;
+                case Type::ID::Double:  temp = static_cast<const Array<double>&>(other);   break;
+                case Type::ID::Variant: temp = static_cast<const Array<Variant>&>(other);  break;
 
                 default:
                 {
@@ -40,36 +43,22 @@ namespace mxl
                 }
             }
 
-            _Type               = temp._Type;
-            _Value.Array        = temp._Value.Array;
-            temp._Type          = Type::ID::Empty;
-            temp._Value.Empty   = nullptr;
+            std::memcpy(this, &temp, sizeof(Variant));
+            std::memset(&temp, 0, sizeof(Variant));
         }
-
         else if (other.IsString())
         {
             Variant temp{String{other}};
-            
-            _Type               = temp._Type;
-            _Value.Array        = temp._Value.Array;
-            temp._Type          = Type::ID::Empty;
-            temp._Value.Empty   = nullptr;
-        }
 
+            std::memcpy(this, &temp, sizeof(Variant));
+            std::memset(&temp, 0, sizeof(Variant));
+        }
         else
         {
-            _Type   = other._Type;
-            _Value  = other._Value;
+            std::memcpy(this, &other, sizeof(Variant));
         }
     }
 
-    inline Variant::Variant(Variant&& other)
-    {
-        _Type               = other._Type;
-        _Value              = other._Value;
-        other._Type         = Type::ID::Empty;
-        other._Value.Empty  = nullptr;
-    }
 
     inline Variant& Variant::operator=(const Variant& other)
     {
@@ -80,13 +69,12 @@ namespace mxl
 
         Variant temp{other};
 
-        _Type               = temp._Type;
-        _Value              = temp._Value;
-        temp._Type          = Type::ID::Empty;
-        temp._Value.Empty   = nullptr;
+        std::memcpy(this, &temp, sizeof(Variant));
+        std::memset(&temp, 0, sizeof(Variant));
 
         return *this;
     }
+
 
     inline Variant& Variant::operator=(Variant&& other)
     {
@@ -95,63 +83,264 @@ namespace mxl
 
         Deallocate();
 
-        _Type               = other._Type;
-        _Value              = other._Value;
-        other._Type         = Type::ID::Empty;
-        other._Value.Empty  = nullptr;
+        std::memcpy(this, &other, sizeof(Variant));
+        std::memset(&other, 0, sizeof(Variant));
 
         return *this;
     }
 
 
-    inline Variant::Variant(const String& string)
-    {
-        String temp{string};
-
-        if (auto buffer = static_cast<char16_t*>(temp))
-        {
-            _Type               = Type::ID::String;
-            _Value.String       = buffer;
-            temp._Container     = nullptr;
-        }
-    }
-
-    inline Variant::Variant(String&& string)
-    {
-        if (auto buffer = static_cast<char16_t*>(string))
-        {
-            _Type               = Type::ID::String;
-            _Value.String       = buffer;
-            string._Container   = nullptr;
-        }
-    }
-
-    inline Variant& Variant::operator=(const String& string)
+    inline Variant::~Variant()
     {
         Deallocate();
-
-        Variant temp{string};
-        _Type                   = temp._Type;
-        _Value                  = temp._Value;
-        temp._Type              = Type::ID::Empty;
-        temp._Value.Empty       = nullptr;
-
-        return *this;
     }
-                                    
 
-    inline Variant& Variant::operator=(String&& string)
+
+    inline Type::ID Variant::TypeID() const
     {
-        Deallocate();
-
-        Variant temp{string};
-        _Type                   = temp._Type;
-        _Value                  = temp._Value;
-        temp._Type              = Type::ID::Empty;
-        temp._Value.Empty       = nullptr;
-
-        return *this;
+        return _Type;
     }
+
+
+    inline bool Variant::IsEmpty() const
+    {
+        return _Type == Type::ID::Empty;
+    }
+
+
+    inline bool Variant::IsNumeric() const
+    {
+        return Type::IsNumericID(_Type);
+    }
+
+
+    inline bool Variant::IsString() const
+    {
+        return _Type == Type::ID::String;
+    }
+
+
+    inline bool Variant::IsDate() const
+    {
+        return _Type == Type::ID::Date;
+    }
+
+
+    inline bool Variant::IsArray() const
+    {
+        return (bool)(_Type & Type::ID::Array);
+    }
+
+
+    inline Type::ID Variant::ArrayTypeID() const
+    {
+        return IsArray() ? _Type ^ Type::ID::Array : Type::ID::Empty;
+    }
+
+
+    inline bool Variant::IsArrayOfTypeID(Type::ID type) const
+    {
+        return IsArray() && (type == (_Type ^ Type::ID::Array));
+    }
+
+
+    inline bool Variant::IsArrayOfTypeID(uint32_t type) const
+    {
+        return IsArray() && ((Type::ID)type == (_Type ^ Type::ID::Array));
+    }
+
+
+    inline Variant::Variant(const String& str)
+    {
+        String temp = str;
+
+        _Type = Type::ID::String;
+        _Value.String = temp.Buffer();
+
+        std::memset(&temp, 0, sizeof(String));
+
+        if (!_Value.String)
+            std::memset(this, 0, sizeof(Variant));
+    }
+
+
+    inline Variant::Variant(String&& str): _Type{Type::ID::String}, _Value{.String = str.Buffer()}
+    {
+        std::memset(&str, 0, sizeof(String));
+
+        if (!_Value.String)
+            std::memset(this, 0, sizeof(Variant));
+    }
+
+
+    inline Variant::Variant(const char* str): Variant(String{str})
+    {
+    }
+
+
+    inline Variant::Variant(const char16_t* str): Variant(String{str})
+    {
+    }
+
+
+    inline Variant::operator String() &&
+    {
+        String str = std::move(operator String&());
+
+        std::memset(this, 0, sizeof(String));
+
+        return str;
+    }
+
+
+    inline Variant::operator String() const &
+    {
+        return operator const String&();
+    }
+
+
+    inline Variant::operator String&()
+    {
+        if (IsString())
+            return reinterpret_cast<String&>(_Value.String);
+
+        MXL_THROW("Invalid conversion; Variant is not a String");
+    }
+
+
+    inline Variant::operator const String&() const
+    {
+        return static_cast<const String&>(
+            const_cast<Variant*>(this)->operator String&()
+        );
+    }
+
+
+    template <ArrayValue _Ty>
+    inline Variant::Variant(const Array<_Ty>& array)
+    {
+        constexpr auto size = sizeof(Array<_Ty>);
+
+        Array<_Ty> temp = array;
+
+        if (auto ptr = static_cast<Array<_Ty>*>(std::malloc(size)))
+        {
+            std::memcpy(ptr, &temp, size);
+            std::memset(&temp, 0, size);
+
+            _Type = Type::GetID<Array<_Ty>>();
+            _Value.Array = &ptr->_Body;
+        }
+        else
+            MXL_THROW("Dynamic allocation failed.");
+    }
+
+
+    template <ArrayValue _Ty>
+    inline Variant::Variant(Array<_Ty>&& array)
+    {
+        constexpr auto size = sizeof(Array<_Ty>);
+        
+        if (auto ptr = static_cast<Array<_Ty>*>(std::malloc(size)))
+        {
+            std::memcpy(ptr, &array, size);
+            std::memset(&array, 0, size);
+
+            _Type = Type::GetID<Array<_Ty>>();
+            _Value.Array = &ptr->_Body;
+        }
+        else
+            MXL_THROW("Dynamic allocation failed.");
+    }
+
+
+    template <ArrayValue _Ty>
+    inline Variant::operator Array<_Ty>() &&
+    {
+        Array<_Ty> array = std::move(operator Array<_Ty>&());
+
+        std::memset(this, 0, sizeof(Variant));
+
+        return array;
+    }
+
+
+    template <ArrayValue _Ty>
+    inline Variant::operator Array<_Ty>() const &
+    {
+        return operator const Array<_Ty>&();
+    }
+
+
+    template <ArrayValue _Ty>
+    inline Variant::operator Array<_Ty>&()
+    {
+        if (IsArray())
+        {
+            if (IsArrayOfTypeID(Type::GetID<typename Array<_Ty>::ValueType>()))
+            {
+                return *reinterpret_cast<Array<_Ty>*>(
+                    (std::byte*)_Value.Array - sizeof(ArrayHeader)
+                );
+            }
+
+            MXL_THROW("Invalid conversion; Variant contains Array of different type");
+        }
+        
+        MXL_THROW("Invalid conversion; Variant is not of type Array");
+    }
+
+
+    template <ArrayValue _Ty>
+    inline Variant::operator const Array<_Ty>&() const
+    {
+        return static_cast<const Array<_Ty>&>(
+            const_cast<Variant*>(this)->operator Array<_Ty>&()
+        );
+    }
+
+
+    template <Numeric _Ty>
+    inline Variant::Variant(_Ty value): _Type{Type::GetID<_Ty>()}
+    {
+        if constexpr (Type::IsSame<_Ty, int16_t>)   _Value.Int16  = value;
+        if constexpr (Type::IsSame<_Ty, int32_t>)   _Value.Int32  = value;
+        if constexpr (Type::IsSame<_Ty, int64_t>)   _Value.Int64  = value;
+        if constexpr (Type::IsSame<_Ty, float>)     _Value.Float  = value;
+        if constexpr (Type::IsSame<_Ty, double>)    _Value.Double = value;
+        if constexpr (Type::IsSame<_Ty, char16_t*>) _Value.String = value;
+    }
+
+
+    template <Numeric _Ty>
+    inline Variant::operator _Ty&()
+    {
+        if (IsNumeric())
+        {
+            if (TypeID() == Type::GetID<_Ty>())
+            {
+                if constexpr (Type::IsSame<_Ty, int16_t>)    return _Value.Int16;
+                if constexpr (Type::IsSame<_Ty, int64_t>)    return _Value.Int64;
+                if constexpr (Type::IsSame<_Ty, int32_t>)    return _Value.Int32;
+                if constexpr (Type::IsSame<_Ty, float>)      return _Value.Float;
+                if constexpr (Type::IsSame<_Ty, double>)     return _Value.Double;
+            }
+            
+            MXL_THROW("Invalid access by reference; Variant is of different numeric type");        
+        }
+
+        MXL_THROW("Invalid access by reference; Variant is not Numeric");
+    }
+
+
+    template <Numeric _Ty>
+    inline Variant::operator const _Ty&() const
+    {
+        return static_cast<const _Ty&>(
+            const_cast<Variant*>(this)->operator _Ty&()
+        );
+    }
+
 
     inline void Variant::Deallocate()
     {
@@ -166,7 +355,7 @@ namespace mxl
     }
 
 
-    inline Variant Variant::operator+(const Variant other) const
+    inline Variant Variant::operator+(const Variant& other) const
     {
         if (IsNumeric())
         {
@@ -190,7 +379,7 @@ namespace mxl
     }
 
 
-    inline Variant Variant::operator-(const Variant other) const
+    inline Variant Variant::operator-(const Variant& other) const
     {
         if (IsNumeric())
         {
@@ -214,7 +403,7 @@ namespace mxl
     }
 
 
-    inline Variant Variant::operator*(const Variant other) const
+    inline Variant Variant::operator*(const Variant& other) const
     {
         if (IsNumeric())
         {
@@ -238,7 +427,7 @@ namespace mxl
     }
 
 
-    inline Variant Variant::operator/(const Variant other) const
+    inline Variant Variant::operator/(const Variant& other) const
     {
         if (IsNumeric())
         {
@@ -362,135 +551,123 @@ namespace mxl
     }
 
 
-    template<Numeric _Ty>
-    inline Variant::Variant(const _Ty value)
+    inline bool Variant::operator==(const Variant& other) const
     {
-        _Type = Type::GetID<_Ty>();
-
-        if constexpr (Type::IsSame<_Ty, int16_t>)   _Value.Int16  = value;
-        if constexpr (Type::IsSame<_Ty, int32_t>)   _Value.Int32  = value;
-        if constexpr (Type::IsSame<_Ty, int64_t>)   _Value.Int64  = value;
-        if constexpr (Type::IsSame<_Ty, float>)     _Value.Float  = value;
-        if constexpr (Type::IsSame<_Ty, double>)    _Value.Double = value;
-    }
-
-
-    template<Numeric _Ty>
-    inline Variant& Variant::operator=(const _Ty value)
-    {
-        Deallocate();
-
-        _Type = Type::GetID<_Ty>();
-
-        if constexpr (Type::IsSame<_Ty, int16_t>)   _Value.Int16  = value;
-        if constexpr (Type::IsSame<_Ty, int32_t>)   _Value.Int32  = value;
-        if constexpr (Type::IsSame<_Ty, int64_t>)   _Value.Int64  = value;
-        if constexpr (Type::IsSame<_Ty, float>)     _Value.Float  = value;
-        if constexpr (Type::IsSame<_Ty, double>)    _Value.Double = value;
-
-        return *this;
-    }
-
-
-    template <ArrayValue _Ty>
-    Variant::Variant(const Array<_Ty>& array)
-    {
-        constexpr auto typeID = Type::GetID<_Ty>();
-
-        if constexpr (typeID != Type::ID::Empty)
+        if (IsEmpty() && other.IsEmpty())
         {
-            if (auto dst = static_cast<Array<_Ty>*>(std::malloc(sizeof(Array<_Ty>))))
+            return true;
+        }
+        else if (IsNumeric() && other.IsNumeric())
+        {
+            switch (other._Type)
             {
-                *dst = array;
-
-                _Type           = Type::ID::Array | typeID;
-                _Value.Array    = reinterpret_cast<ArrayBody*>((char*)dst + sizeof(ArrayHeader));
-            }
-            else
-            {
-                MXL_THROW("Allocation failed when constructing Variant from Array");
+                case Type::ID::Int16:    return operator==(other._Value.Int16);
+                case Type::ID::Int32:    return operator==(other._Value.Int32);
+                case Type::ID::Int64:    return operator==(other._Value.Int64);
+                case Type::ID::Float:    return operator==(other._Value.Float);
+                case Type::ID::Double:   return operator==(other._Value.Double);
+                default: ;
             }
         }
-        else
+        else if (IsString() && other.IsString())
         {
-            MXL_THROW("Invalid attempt to construct Variant from Array containing unsupported data type");
+            return static_cast<const String&>(*this) == static_cast<const String&>(other);
         }
+
+        MXL_THROW("Invalid attempt to perform comparison between incompatible Variants");
     }
 
 
-    template <ArrayValue _Ty>
-    Variant::Variant(Array<_Ty>&& array)
+    inline bool Variant::operator!=(const Variant& other) const
     {
-        constexpr auto typeID = Type::GetID<_Ty>();
+        return !operator==(other);
+    }
 
-        if constexpr (typeID != Type::ID::Empty)
+
+    inline bool Variant::operator<(const Variant& other) const
+    {
+        if (IsEmpty() && other.IsEmpty())
         {
-            if (auto dst = static_cast<Array<_Ty>*>(std::malloc(sizeof(Array<_Ty>))))
+            return true;
+        }
+        else if (IsNumeric() && other.IsNumeric())
+        {
+            switch (other._Type)
             {
-                *dst = std::move(array);
-
-                _Type           = Type::ID::Array | typeID;
-                _Value.Array    = reinterpret_cast<ArrayBody*>((char*)dst + sizeof(ArrayHeader));
-                array._Header   = ArrayHeader{};
-                array._Body     = ArrayBody{};
+                case Type::ID::Int16:    return operator<(other._Value.Int16);
+                case Type::ID::Int32:    return operator<(other._Value.Int32);
+                case Type::ID::Int64:    return operator<(other._Value.Int64);
+                case Type::ID::Float:    return operator<(other._Value.Float);
+                case Type::ID::Double:   return operator<(other._Value.Double);
+                default: ;
             }
-            else
+        }
+        else if (IsString() && other.IsString())
+        {
+            return static_cast<const String&>(*this).Size() < static_cast<const String&>(other).Size();
+        }
+
+        MXL_THROW("Invalid attempt to perform comparison between incompatible Variants");
+    }
+
+
+    inline bool Variant::operator<=(const Variant& other) const
+    {
+        if (IsEmpty() && other.IsEmpty())
+        {
+            return true;
+        }
+        else if (IsNumeric() && other.IsNumeric())
+        {
+            switch (other._Type)
             {
-                MXL_THROW("Allocation failed when move-constructing Variant from Array");
+                case Type::ID::Int16:    return operator<=(other._Value.Int16);
+                case Type::ID::Int32:    return operator<=(other._Value.Int32);
+                case Type::ID::Int64:    return operator<=(other._Value.Int64);
+                case Type::ID::Float:    return operator<=(other._Value.Float);
+                case Type::ID::Double:   return operator<=(other._Value.Double);
+                default: ;
             }
         }
-        else
+        else if (IsString() && other.IsString())
         {
-            MXL_THROW("Invalid attempt to move-construct Variant from Array containing unsupported data type");
-        }
-    }
-
-
-    template <ArrayValue _Ty>
-    Variant& Variant::operator=(const Array<_Ty>& array)
-    {
-        Deallocate();
-
-        Variant temp{array};
-        _Type                   = temp._Type;
-        _Value                  = temp._Value;
-        temp._Type              = Type::ID::Empty;
-        temp._Value.Empty       = nullptr;
-
-        return *this;
-    }
-
-
-    template <ArrayValue _Ty>
-    Variant& Variant::operator=(Array<_Ty>&& array)
-    {
-        Deallocate();
-
-        Variant temp{array};
-        _Type                   = temp._Type;
-        _Value                  = temp._Value;
-        temp._Type              = Type::ID::Empty;
-        temp._Value.Empty       = nullptr;
-
-        return *this;
-    }
-
-
-    template<Numeric _Ty>
-    inline Variant::operator _Ty() const
-    {
-        switch (_Type)
-        {
-            case Type::ID::Int16:     return (_Ty) _Value.Int16     ;
-            case Type::ID::Int32:     return (_Ty) _Value.Int32     ;
-            case Type::ID::Int64:     return (_Ty) _Value.Int64     ;
-            case Type::ID::Float:     return (_Ty) _Value.Float     ;
-            case Type::ID::Double:    return (_Ty) _Value.Double    ;
-            case Type::ID::Empty:     return _Ty{0}                 ;
-            default: ;
+            return static_cast<const String&>(*this).Size() <= static_cast<const String&>(other).Size();
         }
 
-        MXL_THROW("Invalid attempt to cast non-numeric Variant into numeric type");
+        MXL_THROW("Invalid attempt to perform comparison between incompatible Variants");
+    }
+
+
+    inline bool Variant::operator>(const Variant& other) const
+    {
+        return !operator<=(other);
+    }
+
+
+    inline bool Variant::operator>=(const Variant& other) const
+    {
+        if (IsEmpty() && other.IsEmpty())
+        {
+            return true;
+        }
+        else if (IsNumeric() && other.IsNumeric())
+        {
+            switch (other._Type)
+            {
+                case Type::ID::Int16:    return operator>=(other._Value.Int16);
+                case Type::ID::Int32:    return operator>=(other._Value.Int32);
+                case Type::ID::Int64:    return operator>=(other._Value.Int64);
+                case Type::ID::Float:    return operator>=(other._Value.Float);
+                case Type::ID::Double:   return operator>=(other._Value.Double);
+                default: ;
+            }
+        }
+        else if (IsString() && other.IsString())
+        {
+            return static_cast<const String&>(*this).Size() >= static_cast<const String&>(other).Size();
+        }
+
+        MXL_THROW("Invalid attempt to perform comparison between incompatible Variants");
     }
 
 
@@ -637,29 +814,116 @@ namespace mxl
         MXL_THROW("Invalid attempt to perform assign-division with a non-numeric Variant");
     }
 
+
     template<Numeric _Ty>
-    inline _Ty operator+(_Ty value, const Variant& var)
+    inline bool Variant::operator==(const _Ty value) const
+    {
+        switch (_Type)
+        {
+            case Type::ID::Int16:     return _Value.Int16  == value;
+            case Type::ID::Int32:     return _Value.Int32  == value;
+            case Type::ID::Int64:     return _Value.Int64  == value;
+            case Type::ID::Float:     return _Value.Float  == value;
+            case Type::ID::Double:    return _Value.Double == value;
+            default: ;
+        }
+
+        MXL_THROW("Invalid attempt to perform comparison between a number and a non-numeric Variant");
+    }
+
+
+    template<Numeric _Ty>
+    inline bool Variant::operator!=(const _Ty value) const
+    {
+        return !operator==(value);
+    }
+
+
+    template<Numeric _Ty>
+    inline bool Variant::operator<(const _Ty value) const
+    {
+        switch (_Type)
+        {
+            case Type::ID::Int16:     return _Value.Int16  < value;
+            case Type::ID::Int32:     return _Value.Int32  < value;
+            case Type::ID::Int64:     return _Value.Int64  < value;
+            case Type::ID::Float:     return _Value.Float  < value;
+            case Type::ID::Double:    return _Value.Double < value;
+            default: ;
+        }
+
+        MXL_THROW("Invalid attempt to perform comparison between a number and a non-numeric Variant");
+    }
+
+
+    template<Numeric _Ty>
+    inline bool Variant::operator<=(const _Ty value) const
+    {
+        switch (_Type)
+        {
+            case Type::ID::Int16:     return _Value.Int16  < value;
+            case Type::ID::Int32:     return _Value.Int32  < value;
+            case Type::ID::Int64:     return _Value.Int64  < value;
+            case Type::ID::Float:     return _Value.Float  < value;
+            case Type::ID::Double:    return _Value.Double < value;
+            default: ;
+        }
+
+        MXL_THROW("Invalid attempt to perform comparison between a number and a non-numeric Variant");
+    }
+
+
+    template<Numeric _Ty>
+    inline bool Variant::operator>(const _Ty value) const
+    {
+        return !operator<=(value);
+    }
+
+
+    template<Numeric _Ty>
+    inline bool Variant::operator>=(const _Ty value) const
+    {
+        switch (_Type)
+        {
+            case Type::ID::Int16:     return _Value.Int16  >= value;
+            case Type::ID::Int32:     return _Value.Int32  >= value;
+            case Type::ID::Int64:     return _Value.Int64  >= value;
+            case Type::ID::Float:     return _Value.Float  >= value;
+            case Type::ID::Double:    return _Value.Double >= value;
+            default: ;
+        }
+
+        MXL_THROW("Invalid attempt to perform comparison between a number and a non-numeric Variant");
+    }
+
+
+    template<Numeric _Ty>
+    inline _Ty operator+(const _Ty value, const Variant& var)
     {
         return value + static_cast<_Ty>(var);
     }
 
+
     template<Numeric _Ty>
-    inline _Ty operator-(_Ty value, const Variant& var)
+    inline _Ty operator-(const _Ty value, const Variant& var)
     {
         return value + static_cast<_Ty>(var);
     }
 
+
     template<Numeric _Ty>
-    inline _Ty operator*(_Ty value, const Variant& var)
+    inline _Ty operator*(const _Ty value, const Variant& var)
     {
         return value * static_cast<_Ty>(var);
     }
 
+
     template<Numeric _Ty>
-    inline _Ty operator/(_Ty value, const Variant& var)
+    inline _Ty operator/(const _Ty value, const Variant& var)
     {
         return value / static_cast<_Ty>(var);
     }
+
 
     template<Numeric _Ty>
     inline _Ty& operator+=(_Ty& value, const Variant& var)
@@ -667,11 +931,13 @@ namespace mxl
         return (value += static_cast<_Ty>(var));
     }
 
+
     template<Numeric _Ty>
     inline _Ty& operator-=(_Ty& value, const Variant& var)
     {
         return (value -= static_cast<_Ty>(var));
     }
+
 
     template<Numeric _Ty>
     inline _Ty& operator*=(_Ty& value, const Variant& var)
@@ -679,26 +945,70 @@ namespace mxl
         return (value *= static_cast<_Ty>(var));
     }
 
+
     template<Numeric _Ty>
     inline _Ty& operator/=(_Ty& value, const Variant& var)
     {
         return (value /= static_cast<_Ty>(var));
     }
-}
 
 
-inline std::ostream& operator<<(std::ostream &os, const mxl::Variant& var)
-{
-    switch (var.Type())
+    template<Numeric _Ty>
+    inline bool operator==(_Ty value, const Variant& var)
     {
-        case mxl::Type::ID::Int16:       return os << var.Int16();
-        case mxl::Type::ID::Int32:       return os << var.Int32();
-        case mxl::Type::ID::Int64:       return os << var.Int64();
-        case mxl::Type::ID::Float:       return os << var.Float();
-        case mxl::Type::ID::Double:      return os << var.Double();
-        case mxl::Type::ID::String:      return os << mxl::String::Str16to8(var.Value().String);
-        default: ;
+        return (value == static_cast<_Ty>(var));
     }
 
-    return os;
+
+    template<Numeric _Ty>
+    inline bool operator!=(_Ty value, const Variant& var)
+    {
+        return (value != static_cast<_Ty>(var));
+    }
+
+
+    template<Numeric _Ty>
+    inline bool operator<(_Ty value, const Variant& var)
+    {
+        return (value < static_cast<_Ty>(var));
+    }
+
+
+    template<Numeric _Ty>
+    inline bool operator<=(_Ty value, const Variant& var)
+    {
+        return (value <= static_cast<_Ty>(var));
+    }
+
+
+    template<Numeric _Ty>
+    inline bool operator>(_Ty value, const Variant& var)
+    {
+        return (value > static_cast<_Ty>(var));
+    }
+
+
+    template<Numeric _Ty>
+    inline bool operator>=(_Ty value, const Variant& var)
+    {
+        return (value >= static_cast<_Ty>(var));
+    }
+
+
+    inline std::ostream& operator<<(std::ostream &os, const Variant& var)
+    {
+        switch (var.TypeID())
+        {
+            case Type::ID::Int16:       return os << static_cast<const int16_t&>(var);
+            case Type::ID::Int32:       return os << static_cast<const int32_t&>(var);
+            case Type::ID::Int64:       return os << static_cast<const int64_t&>(var);
+            case Type::ID::Float:       return os << static_cast<const float&>(var);
+            case Type::ID::Double:      return os << static_cast<const double&>(var);
+            case Type::ID::String:      return os << static_cast<const String&>(var);
+            case Type::ID::Empty:       return os << "Empty";
+            default: ;
+        }
+
+        return os;
+    }
 }

--- a/include/MinXL/Core/Implementation/Variant.hpp
+++ b/include/MinXL/Core/Implementation/Variant.hpp
@@ -5,6 +5,7 @@
 #include "MinXL/Core/Interface/Array.hpp"
 #include "MinXL/Core/Interface/String.hpp"
 #include "MinXL/Core/Interface/Variant.hpp"
+#include "Variant.hpp"
 
 
 namespace mxl
@@ -668,6 +669,87 @@ namespace mxl
         }
 
         MXL_THROW("Invalid attempt to perform comparison between incompatible Variants");
+    }
+
+
+    inline Variant Variant::operator-() const
+    {
+        if (IsNumeric())
+        {
+            auto ret = *this;
+            ret *= -1;
+            return ret;
+        }
+        else if (IsEmpty())
+        {
+            return Variant{};
+        }
+
+        MXL_THROW("Invalid attempt to change signal of non-numeric Variant");
+    }
+
+
+    inline Variant& Variant::operator++()
+    {
+        if (IsNumeric())
+        {
+            switch (_Type)
+            {
+                case Type::ID::Int16:     _Value.Int16++;
+                case Type::ID::Int32:     _Value.Int32++;
+                case Type::ID::Int64:     _Value.Int64++;
+                case Type::ID::Float:     _Value.Float++;
+                case Type::ID::Double:    _Value.Double++;
+                case Type::ID::Empty:     *this = Variant{0} + 1;
+                default: ;
+            }
+        }
+        else
+        {
+            MXL_THROW("Invalid attempt to pre-increment non-numeric Variant");
+        }
+
+        return *this;
+    }
+
+
+    inline Variant Variant::operator++(int)
+    {
+        auto temp = *this;
+        operator++();
+        return temp;
+    }
+
+
+    inline Variant& Variant::operator--()
+    {
+        if (IsNumeric())
+        {
+            switch (_Type)
+            {
+                case Type::ID::Int16:     _Value.Int16--;
+                case Type::ID::Int32:     _Value.Int32--;
+                case Type::ID::Int64:     _Value.Int64--;
+                case Type::ID::Float:     _Value.Float--;
+                case Type::ID::Double:    _Value.Double--;
+                case Type::ID::Empty:     *this = Variant{0} - 1;
+                default: ;
+            }
+        }
+        else
+        {
+            MXL_THROW("Invalid attempt to pre-decrement non-numeric Variant");
+        }
+
+        return *this;
+    }
+
+
+    inline Variant Variant::operator--(int)
+    {
+        auto temp = *this;
+        operator--();
+        return temp;
     }
 
 

--- a/include/MinXL/Core/Interface/Array.hpp
+++ b/include/MinXL/Core/Interface/Array.hpp
@@ -57,19 +57,6 @@ namespace mxl
 
         Array(const Variant& var);
         Array(Variant&& var);
-        
-        template<Castable<_Ty>... _Args>
-        static Array<_Ty> FromList(_Args&&... args)
-        {
-            Array<_Ty> arr(sizeof...(_Args), 1);
-
-            int32_t i = 0;
-            (...,
-                (arr(i++, 0) = static_cast<_Ty>(std::move(args)))
-            );            
-
-            return arr;
-        }
 
         ~Array();
 
@@ -80,6 +67,7 @@ namespace mxl
         _Ty&        operator()(const uint64_t row, const uint64_t col);
 
     public:
+
         inline auto Size() const         { return _Body.Columns.ElementCount * _Body.Rows.ElementCount;              }
         inline auto Data() const         { return static_cast<_Ty*>(_Body.Data);                                     }
         inline auto Rows() const         { return _Body.Rows.ElementCount;                                           }
@@ -87,6 +75,7 @@ namespace mxl
         inline auto ElementSize() const  { return _Body.ElementSize;                                                 }
         inline auto Column(uint64_t col) { return std::make_pair(&operator()(0, col), &operator()(Rows(), col));     }
 
+        // Test
         void Resize(const uint64_t rows, const uint64_t cols);
 
     private:
@@ -94,8 +83,23 @@ namespace mxl
         static void Deallocate(ArrayBody* array);
     };
 
-    template <ArrayValue _Ty> _Ty*          begin(Array<_Ty>& arr);
-    template <ArrayValue _Ty> _Ty*          end(Array<_Ty>& arr);
-    template <ArrayValue _Ty> const _Ty*    begin(const Array<_Ty>& arr);
-    template <ArrayValue _Ty> const _Ty*    end(const Array<_Ty>& arr);
+
+    //
+    // Tuples are simply a one-dimension mxl::Array<mxl::Variant>.
+    // They only exist for convenience, allowing the creation of inline arrays
+    // without the cumbersomeness of populating the array item by item.
+    // mxl::Tuple can be used in every way you would use mxl::Array.
+    //
+    // Example:
+    // >>> auto tp = mxl::Tuple{1.2, 2, "3"};
+    //
+    template<ArrayValue _Ty = Variant>
+    class Tuple: public Array<_Ty>
+    {
+    public:
+        Tuple(std::initializer_list<_Ty> args);
+
+        template<Castable<_Ty>... _Ts>
+        Tuple(_Ts... args);
+    };
 }

--- a/include/MinXL/Core/Interface/String.hpp
+++ b/include/MinXL/Core/Interface/String.hpp
@@ -31,31 +31,33 @@ namespace mxl
         String();
         String(const String& other);
         String(String&& other);
-        String& operator=(const String& other);
-        String& operator=(String&& other);
         String(const char16_t* str);
         String(const char* str);
         String(const Variant& var);
         String(Variant&& var);
 
+        String& operator=(const String& other);
+        String& operator=(String&& other);
+
         ~String();
 
     private:
         String(StringContainer* str);
+        StringContainer*        Container() const;
 
 
     public:
         uint64_t                Size() const;
         char16_t*               Buffer() const;
-        StringContainer*        Container() const;
-
-        static bool             Compare(const char16_t* lhs, const char16_t* rhs);
-        static const char*      Str16to8(const char16_t* str);
-        static const char16_t*  Str8to16(const char* str);
+        std::unique_ptr<char[]> CStr() const;
 
         bool                    operator==(const String& other) const;
         bool                    operator!=(const String& other) const;
 
+    private:
+        static bool Compare(const char16_t* lhs, const char16_t* rhs);
+        static std::unique_ptr<char[]> Char16to8(const char16_t* str);
+        static std::unique_ptr<char16_t[]> Char8to16(const char* str);
 
     private:
         void                    Allocate(const char16_t* str);

--- a/include/MinXL/Core/Interface/String.hpp
+++ b/include/MinXL/Core/Interface/String.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "MinXL/Core/Common.hpp"
 #include "MinXL/Core/Types.hpp"
 
 
@@ -12,62 +11,57 @@ namespace mxl
         uint32_t Size;
     };
 
+
     struct StringContainer
     {
-        StringHeader    Head;
-        char16_t        Buffer[2];
+        StringHeader Header;
+        char16_t Buffer[2];
     };
 
 
     class String
     {
         friend class Variant;
-        
-    public:
-        using Container = StringContainer;
 
     private:
-        Container* _Container{nullptr};
+        char16_t* _Buffer;
+
 
     public:
         String();
-        String(const char16_t* str);
-        String(const char* str);
         String(const String& other);
-        String(const std::string& str);
-        String(const std::string_view& str);
-        String(const std::stringstream& str);
-
         String(String&& other);
-        
         String& operator=(const String& other);
         String& operator=(String&& other);
-
+        String(const char16_t* str);
+        String(const char* str);
         String(const Variant& var);
         String(Variant&& var);
-        String& operator=(const Variant& other);
-        String& operator=(Variant&& other);
-
-        bool operator==(const String& other);
-        bool operator!=(const String& other);
-
-        inline operator char16_t*() const { return _Container ? _Container->Buffer : nullptr; }
 
         ~String();
 
     private:
-        void                    Allocate(const char16_t* str);
-        void                    Allocate(const String& str);
-        static void             Deallocate(char16_t* str);
-        static void             Deallocate(String& str);
+        String(StringContainer* str);
+
 
     public:
         uint64_t                Size() const;
-        const char*             CStr() const;
-        const char16_t*         WStr() const;
+        char16_t*               Buffer() const;
+        StringContainer*        Container() const;
 
         static bool             Compare(const char16_t* lhs, const char16_t* rhs);
         static const char*      Str16to8(const char16_t* str);
         static const char16_t*  Str8to16(const char* str);
+
+        bool                    operator==(const String& other) const;
+        bool                    operator!=(const String& other) const;
+
+
+    private:
+        void                    Allocate(const char16_t* str);
+        static void             Deallocate(char16_t* str);
     };
+
+
+    std::ostream& operator<<(std::ostream &os, const String& str);
 }

--- a/include/MinXL/Core/Interface/Variant.hpp
+++ b/include/MinXL/Core/Interface/Variant.hpp
@@ -1,12 +1,11 @@
 #pragma once
 
-#include "MinXL/Core/Common.hpp"
 #include "MinXL/Core/Types.hpp"
 
 
 namespace mxl
 {
-    union VariantValue
+    union VariantUnion
     {
         uint8_t         Byte;
         int16_t         Int16;
@@ -19,113 +18,92 @@ namespace mxl
         void*           Empty;
     };
 
+
     class Variant
     {
-        friend class String;
-
-    public:
-        using ValueType = VariantValue;
-
-        Variant();
-        ~Variant();
-
     private:
-        Type::ID                _Type{Type::ID::Empty};
+        Type::ID                _Type;
         uint8_t                 _ReservedMid[6];
-        ValueType               _Value{0};
+        VariantUnion            _Value;
         uint8_t                 _ReservedEnd[8];
 
-    public:
-        inline auto Type()       const { return _Type;                           }
-        inline bool IsEmpty()    const { return _Type == Type::ID::Empty;        }
-        inline bool IsNumeric()  const { return Type::IsNumeric(_Type);          }
-        inline bool IsString()   const { return _Type == Type::ID::String;       }
-        inline bool IsDate()     const { return _Type == Type::ID::Date;         }
-        inline bool IsArray()    const { return (bool)(_Type & Type::ID::Array); }
-
-        inline const ValueType& Value() const
-        {
-            return _Value;
-        }
-
-        inline ValueType& Value()
-        {
-            return _Value;
-        }
-
-        // Direct numeric accessors
-
-        inline auto& Int16()                { if (_Type == Type::ID::Int16)     return _Value.Int16;    MXL_THROW("Invalid direct access; Variant is not of type Int16");  }
-        inline auto& Int32()                { if (_Type == Type::ID::Int32)     return _Value.Int32;    MXL_THROW("Invalid direct access; Variant is not of type Int32");  }
-        inline auto& Int64()                { if (_Type == Type::ID::Int64)     return _Value.Int64;    MXL_THROW("Invalid direct access; Variant is not of type Int64");  }
-        inline auto& Float()                { if (_Type == Type::ID::Float)     return _Value.Float;    MXL_THROW("Invalid direct access; Variant is not of type Float");  }
-        inline auto& Double()               { if (_Type == Type::ID::Double)    return _Value.Double;   MXL_THROW("Invalid direct access; Variant is not of type Double"); }
-
-        inline const auto& Int16() const    { if (_Type == Type::ID::Int16)     return _Value.Int16;    MXL_THROW("Invalid direct access; Variant is not of type Int16");  }
-        inline const auto& Int32() const    { if (_Type == Type::ID::Int32)     return _Value.Int32;    MXL_THROW("Invalid direct access; Variant is not of type Int32");  }
-        inline const auto& Int64() const    { if (_Type == Type::ID::Int64)     return _Value.Int64;    MXL_THROW("Invalid direct access; Variant is not of type Int64");  }
-        inline const auto& Float() const    { if (_Type == Type::ID::Float)     return _Value.Float;    MXL_THROW("Invalid direct access; Variant is not of type Float");  }
-        inline const auto& Double() const   { if (_Type == Type::ID::Double)    return _Value.Double;   MXL_THROW("Invalid direct access; Variant is not of type Double"); }
-
-        Type::ID ArrayType() const
-        {
-            return IsArray() ? _Type ^ Type::ID::Array : Type::ID::Empty;
-        }
-
-        bool IsArrayOfType(Type::ID type) const
-        {
-            return IsArray() && (type == (_Type ^ Type::ID::Array));
-        }
-
-        bool IsArrayOfType(uint32_t type) const
-        {
-            return IsArray() && ((Type::ID)type == (_Type ^ Type::ID::Array));
-        }
-
-    private:
-        void Deallocate();
 
     public:
-        // Copy/Move Construction/Assignment
+        Variant();
+        
+        // Variant <=> Variant
 
         Variant(const Variant& other);
         Variant(Variant&& other);
         Variant& operator=(const Variant& other);
         Variant& operator=(Variant&& other);
 
-        // Conversion from/to String + String operations
+        // Variant <=> String
 
-        Variant(const String& string);
-        Variant(String&& string);
-        Variant& operator=(const String& string);
-        Variant& operator=(String&& string);
+        Variant(const String& str);
+        Variant(String&& str);
+        Variant(const char* str);
+        Variant(const char16_t* str);
+        explicit operator String() &&;
+        explicit operator String() const &;
+        explicit operator String&();
+        explicit operator const String&() const;
 
-        // Conversion from/to Array
 
-        template<ArrayValue _Ty> Variant(const Array<_Ty>& array);
-        template<ArrayValue _Ty> Variant(Array<_Ty>&& array);
-        template<ArrayValue _Ty> Variant& operator=(const Array<_Ty>& array);
-        template<ArrayValue _Ty> Variant& operator=(Array<_Ty>&& array);
+        // Variant <=> Array
 
-        // Conversion from/to primitives
+        template <ArrayValue _Ty> Variant(const Array<_Ty>& array);
+        template <ArrayValue _Ty> Variant(Array<_Ty>&& array);
+        template <ArrayValue _Ty> explicit operator Array<_Ty>() &&;
+        template <ArrayValue _Ty> explicit operator Array<_Ty>() const &;
+        template <ArrayValue _Ty> explicit operator Array<_Ty>&();
+        template <ArrayValue _Ty> explicit operator const Array<_Ty>&() const;
 
-        template<Numeric _Ty> Variant(const _Ty value);
-        template<Numeric _Ty> Variant& operator=(const _Ty value);
-        template<Numeric _Ty> operator _Ty() const;
+        // Variant <=> Numeric
 
-        // Math operations with Variants
+        template <Numeric _Ty> Variant(_Ty value);
+        template <Numeric _Ty> explicit operator _Ty&();
+        template <Numeric _Ty> explicit operator const _Ty&() const;
 
-        Variant  operator+(const Variant other) const;
-        Variant  operator-(const Variant other) const;
-        Variant  operator*(const Variant other) const;
-        Variant  operator/(const Variant other) const;
-        Variant& operator+=(const Variant& other);
-        Variant& operator-=(const Variant& other);
-        Variant& operator*=(const Variant& other);
-        Variant& operator/=(const Variant& other);
+        ~Variant();
 
-        // Math operations with numeric types
+    public:
+        Type::ID    TypeID() const;
+        bool        IsEmpty() const;
+        bool        IsNumeric() const;
+        bool        IsString() const;
+        bool        IsDate() const;
+        bool        IsArray() const;
+        Type::ID    ArrayTypeID() const;
+        bool        IsArrayOfTypeID(Type::ID type) const;
+        bool        IsArrayOfTypeID(uint32_t type) const;
+
+
+    private:
+        void Deallocate();
+
+
+    public:
+
+        // Variant <> Variant operators
+
+        Variant     operator+(const Variant& other) const;
+        Variant     operator-(const Variant& other) const;
+        Variant     operator*(const Variant& other) const;
+        Variant     operator/(const Variant& other) const;
+        Variant&    operator+=(const Variant& other);
+        Variant&    operator-=(const Variant& other);
+        Variant&    operator*=(const Variant& other);
+        Variant&    operator/=(const Variant& other);
+        bool        operator==(const Variant& other) const;
+        bool        operator!=(const Variant& other) const;
+        bool        operator<(const Variant& other) const;
+        bool        operator<=(const Variant& other) const;
+        bool        operator>(const Variant& other) const;
+        bool        operator>=(const Variant& other) const;
         
+        // Variant <> Primitive operators
+
         template<Numeric _Ty> Variant   operator+(const _Ty value) const;
         template<Numeric _Ty> Variant   operator-(const _Ty value) const;
         template<Numeric _Ty> Variant   operator*(const _Ty value) const;
@@ -134,7 +112,16 @@ namespace mxl
         template<Numeric _Ty> Variant&  operator-=(const _Ty value);
         template<Numeric _Ty> Variant&  operator*=(const _Ty value);
         template<Numeric _Ty> Variant&  operator/=(const _Ty value);
+        template<Numeric _Ty> bool      operator==(const _Ty value) const;
+        template<Numeric _Ty> bool      operator!=(const _Ty value) const;
+        template<Numeric _Ty> bool      operator<(const _Ty value) const;
+        template<Numeric _Ty> bool      operator<=(const _Ty value) const;
+        template<Numeric _Ty> bool      operator>(const _Ty value) const;
+        template<Numeric _Ty> bool      operator>=(const _Ty value) const;
+
     };
+
+    // Primitive <> Variant operators
 
     template<Numeric _Ty> _Ty  operator+(_Ty value, const Variant& var);
     template<Numeric _Ty> _Ty  operator-(_Ty value, const Variant& var);
@@ -144,7 +131,13 @@ namespace mxl
     template<Numeric _Ty> _Ty& operator-=(_Ty value, const Variant& var);
     template<Numeric _Ty> _Ty& operator*=(_Ty value, const Variant& var);
     template<Numeric _Ty> _Ty& operator/=(_Ty value, const Variant& var);
+    template<Numeric _Ty> bool operator==(const _Ty value, const Variant& var);
+    template<Numeric _Ty> bool operator!=(const _Ty value, const Variant& var);
+    template<Numeric _Ty> bool operator<(const _Ty value, const Variant& var);
+    template<Numeric _Ty> bool operator<=(const _Ty value, const Variant& var);
+    template<Numeric _Ty> bool operator>(const _Ty value, const Variant& var);
+    template<Numeric _Ty> bool operator>=(const _Ty value, const Variant& var);
 
+
+    std::ostream& operator<<(std::ostream &os, const Variant& var);
 }
-
-std::ostream& operator<<(std::ostream &os, const mxl::Variant& var);

--- a/include/MinXL/Core/Interface/Variant.hpp
+++ b/include/MinXL/Core/Interface/Variant.hpp
@@ -119,6 +119,13 @@ namespace mxl
         template<Numeric _Ty> bool      operator>(const _Ty value) const;
         template<Numeric _Ty> bool      operator>=(const _Ty value) const;
 
+        // Unary operators
+
+        Variant& operator++();
+        Variant  operator++(int);
+        Variant  operator-() const;
+        Variant& operator--();
+        Variant  operator--(int);
     };
 
     // Primitive <> Variant operators

--- a/include/MinXL/Core/Types.hpp
+++ b/include/MinXL/Core/Types.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "Common.hpp"
-
 namespace mxl
 {
     class Variant;
@@ -18,27 +16,67 @@ namespace mxl
                     std::remove_const_t<_T1>, std::remove_const_t<_T2>
                 >;
             };
-        };
+        }
 
-        // Checks if two types are equal. Ignores const.
+        //
+        // Check if two types are equal. Ignores const.
+        //
         template <typename _T1, typename _T2> 
         inline constexpr bool IsSame = Detail::IsSameType<_T1, _T2>::value;
-    };
+
+        namespace Detail
+        {
+            template <typename _Ty>
+            struct IsNumericType {
+                static constexpr bool value = IsSame<_Ty, int16_t>
+                    || IsSame<_Ty, int32_t>
+                    || IsSame<_Ty, int64_t>
+                    || IsSame<_Ty, float>
+                    || IsSame<_Ty, double>;
+            };
+        }
+
+        //
+        // Check if type is Numeric. Ignores const.
+        //
+        template <typename _Ty> 
+        inline constexpr bool IsNumeric = Detail::IsNumericType<_Ty>::value;
+    }
 
     // Supported numeric types
-    template <typename _Ty> concept Numeric = 
-        Type::IsSame<_Ty, int16_t>
-        || Type::IsSame<_Ty, int16_t>
-        || Type::IsSame<_Ty, int32_t>
-        || Type::IsSame<_Ty, int64_t>
-        || Type::IsSame<_Ty, float>
-        || Type::IsSame<_Ty, double>;
+    template <typename _Ty> concept Numeric = Type::IsNumeric<_Ty>;
+
 
     // Valid Array value type (Supported numeric types + Variant)
     template <typename _Ty> concept ArrayValue = Numeric<_Ty> || Type::IsSame<_Ty, Variant>;
     template <ArrayValue _Ty> class Array;
     struct ArrayHeader;
     struct ArrayBody;
+
+    namespace Type
+    {
+        namespace Detail
+        {
+            template <class, template <class> class>
+            struct IsInstanceType : public std::false_type {};
+
+            template <class _T1, template <class> class _T2>
+            struct IsInstanceType<_T2<_T1>, _T2> : public std::true_type {};
+
+            template<typename _Ty>
+            struct IsArrayType {
+                static constexpr bool value = IsInstanceType<std::remove_const_t<_Ty>, Array>::value;
+            };
+        }
+
+        template <typename _Ty>
+        inline constexpr bool IsArray = Detail::IsArrayType<_Ty>::value;
+    }
+
+    template <typename _Ty> concept VariantValue    = Numeric<_Ty> || Type::IsSame<_Ty, String>     || Type::IsArray<_Ty>;
+    template <typename _Ty> concept VariantValueRaw = Numeric<_Ty> || Type::IsSame<_Ty, char16_t*>  || Type::IsSame<_Ty, ArrayBody*>;
+
+    template <typename _Fr, typename _To> concept Castable = requires { static_cast<_To>(_Fr{}); };
 
     namespace Type
     {
@@ -73,23 +111,8 @@ namespace mxl
         inline constexpr ID operator|=(ID& rhs, ID lhs) { rhs = rhs | lhs; return rhs; }
         inline constexpr ID operator~(ID id)            { return (Type::ID)(~(uint16_t)(id)); }
 
-        inline constexpr bool IsNumeric(ID id)
-        {
-            switch (id)
-            {
-                case ID::Int16:
-                case ID::Int32:
-                case ID::Int64:
-                case ID::Float:
-                case ID::Double:
-                    return true;
-                default:
-                    return false;
-            }
-        }
 
-        template <typename _Ty>
-        inline consteval ID GetID()
+        template <typename _Ty> consteval ID GetID()
         {
             if constexpr (IsSame<_Ty, short> || IsSame<_Ty, int16_t>)
                 return ID::Int16;
@@ -105,12 +128,25 @@ namespace mxl
                 return ID::String;
             if constexpr (IsSame<_Ty, Variant>)
                 return ID::Variant;
+            if constexpr (IsArray<_Ty>)
+                return GetID<typename _Ty::ValueType>() | ID::Array;
 
             return ID::Empty;
         }
 
+
+        constexpr bool IsNumericID(ID id)
+        {
+            return id == Type::ID::Int16
+                || id == Type::ID::Int32
+                || id == Type::ID::Int64
+                || id == Type::ID::Float
+                || id == Type::ID::Double;
+        }
+
+
         // Translates Excel date to Tuple containing Year, Month and Day
-        inline constexpr std::tuple<uint16_t, uint8_t, uint8_t> DeserializeDate(double date)
+        constexpr std::tuple<uint16_t, uint8_t, uint8_t> DeserializeDate(double date)
         {
             // I have no idea how this does what it does, but it works and it's fast.
             // Credits: https://www.codeproject.com/Articles/2750/Excel-Serial-Date-to-Day-Month-Year-and-Vice-Versa
@@ -129,4 +165,4 @@ namespace mxl
             return {year, month, day};
         }
     };
-};
+}


### PR DESCRIPTION
- Created `mxl::Tuple` to make the creation of inline mxl::Arrays easier and more semantic. Behaves the same and can be used interchangeably with mxl::Array. Currently only supports one-dimensional Arrays;
> **Usage:**
> ```cpp
> auto tp1 = mxl::Tuple{1, "random string", 2.3, 4.8f}; // will create an mxl::Tuple of mxl::Variants
> auto tp2 = mxl::Tuple<double>{1, 2, 3.3, 4.8f};  // will create an mxl::Tuple of doubles
> return mxl::Variant{std::move(tp2)}; // will work fine if you're returning to Excel
> ```
---
- Added idiomatic way of accessing a reference to `mxl::Variant`'s underlying data without std::move'ing it around; to be used with try-catch blocks
> **Usage:**
> ```cpp
> mxl::Variant MyFunction(mxl::Variant& arrayOfDoubles)
> {
>     try
>     {
>         for (const auto& value : static_cast<mxl::Array<double>&>(arrayOfDoubles)
>             std::cout << value << '\n';
>     }
>     catch (mxl::Exception& e)
>     {
>         // Return the error to Excel in case it was not, in fact, an array of doubles
>         return {e.what()};
>     }
> }
> 
> ```
---
- Added unary mathematical operators to `mxl::Variant` (post and pre increment/decrement + negative)
> **Usage:**
> ```cpp
> mxl::Variant v = 10;
> v++; // will throw an exception if the mxl::Variant is not numeric
> std::cout << -v << '\n'; // will print '9'
> ```
---
- `mxl::String::CStr` allocates a new buffer for the converted string and used to return a raw pointer to it; now it returns a std::unique_ptr
> **Usage:**
> ```cpp
> // mxl::String's underlying buffer is a char16_t[]
> auto str = mxl::String{"My string"};
> std::unique_ptr ptr = str16.CStr(); // will be freed once the scope ends
> ```